### PR TITLE
replaced schema attribute with meta. #4

### DIFF
--- a/app-settings/shows.js
+++ b/app-settings/shows.js
@@ -20,7 +20,6 @@ exports.app_settings = function(ddoc, req) {
 
   var settings = (ddoc && ddoc.app_settings) || {},
       meta = ddoc.kanso || ddoc.couchapp,
-      schema = meta && meta.config && meta.config.settings_schema,
       path = req.query.objectpath;
 
   if (path) {
@@ -30,7 +29,7 @@ exports.app_settings = function(ddoc, req) {
   return {
     body: JSON.stringify({
       settings: settings,
-      schema: schema
+      meta: meta
     }),
     headers: {
       'Content-Type': 'application/json;charset=utf-8'


### PR DESCRIPTION
This makes more app info available and the schema is typically
found at `meta.config.settings_schema`.
